### PR TITLE
Update webpack config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 
 script:
   - gulp build --silent
-  - http-server --silent -p 8080 -a 0.0.0.0 &
+  - http-server ./dist --silent -p 8080 -a 0.0.0.0 &
   - cd selenium-tests
   - mvn -q test -Dremote=sauce
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_script:
   - npm install -g gulp http-server codeclimate-test-reporter
 
 script:
-  - gulp build --silent
+  - npm run test
+  - npm run build
   - http-server ./dist --silent -p 8080 -a 0.0.0.0 &
   - cd selenium-tests
   - mvn -q test -Dremote=sauce

--- a/build/build.js
+++ b/build/build.js
@@ -1,0 +1,28 @@
+/* eslint-env shelljs */
+
+require('shelljs/global');
+env.NODE_ENV = 'production';
+
+const path = require('path');
+const webpack = require('webpack');
+
+const config = require('../config');
+const webpackConfig = require('./webpack.prod.config');
+
+var assetsPath = path.join(config.build.assetsRoot, config.build.assetsSubDirectory);
+rm('-rf', assetsPath);
+mkdir('-p', assetsPath);
+cp('-R', 'static/', assetsPath);
+
+webpack(webpackConfig, function (err, stats) {
+  if (err) {
+    throw err;
+  }
+  process.stdout.write(stats.toString({
+    colors: true,
+    modules: false,
+    children: false,
+    chunks: false,
+    chunkModules: false
+  }) + '\n');
+});

--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -25,7 +25,11 @@ var devServer = new WebpackDevServer(compiler, {
   },
   publicPath: webpackConfig.output.publicPath,
   stats: {
-    colors: true
+    colors: true,
+    modules: false,
+    children: false,
+    chunks: false,
+    chunkModules: false
   }
 });
 

--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-process-env, no-console */
+
+process.env.NODE_ENV = 'development';
+
+const webpack = require('webpack');
+const WebpackDevServer = require('webpack-dev-server');
+
+const webpackConfig = require('./webpack.dev.config');
+const devServerConfig = require('./dev-server.config');
+
+var compiler = webpack(webpackConfig);
+
+compiler.plugin('done', (stats) => {
+  console.log('[webpack] Build successful!');
+});
+
+var devServer = new WebpackDevServer(compiler, {
+  hot: true,
+  quiet: false,
+  noInfo: true,
+  lazy: false,
+  watchOptions: {
+    aggregateTimeout: 300,
+    poll: 1000
+  },
+  publicPath: webpackConfig.output.publicPath,
+  stats: {
+    colors: true
+  }
+});
+
+devServer.listen(devServerConfig.SERVER_PORT, devServerConfig.SERVER_HOST, (err) => {
+  if (err) {
+    throw err;
+  }
+  console.log('[webpack-dev-server] http://' + devServerConfig.SERVER_HOST + ':' + devServerConfig.SERVER_PORT + '/webpack-dev-server/index.html');
+});

--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -4,7 +4,6 @@ const config = require('../config');
 const projectRoot = path.resolve(__dirname, '../');
 
 module.exports = {
-  cache: true,
   entry: {
     app: [
       'babel-polyfill',
@@ -12,7 +11,7 @@ module.exports = {
     ]
   },
   resolve: {
-    extensions: [ '', '.js', '.ts' ],
+    extensions: [ '', '.js' ],
     fallback: [ path.join(__dirname, '../node_modules') ],
     alias: {
       src: path.resolve(__dirname, '../src')

--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -1,5 +1,8 @@
 const path = require('path');
 
+const config = require('../config');
+const projectRoot = path.resolve(__dirname, '../');
+
 module.exports = {
   cache: true,
   entry: {
@@ -9,17 +12,30 @@ module.exports = {
     ]
   },
   resolve: {
-    root: path.resolve('src', 'js'),
-    modulesDirectories: [ 'node_modules' ],
-    extensions: [ '', '.js' ]
+    extensions: [ '', '.js', '.ts' ],
+    fallback: [ path.join(__dirname, '../node_modules') ],
+    alias: {
+      src: path.resolve(__dirname, '../src')
+    }
+  },
+  resolveLoader: {
+    fallback: [ path.join(__dirname, '../node_modules') ]
   },
   output: {
-    path: path.join(__dirname, '..', 'dist', 'js'),
-    publicPath: '/dist/js/',
+    path: config.build.assetsRoot,
+    publicPath: config.build.assetsPublicPath,
     filename: '[name].js',
     chunkFilename: '[chunkhash].js'
   },
   module: {
+    preLoaders: [
+      {
+        test: /\.js$/,
+        loader: 'eslint',
+        include: projectRoot,
+        exclude: /node_modules/
+      }
+    ],
     loaders: [
       {
         test: /\.js$/,
@@ -27,6 +43,9 @@ module.exports = {
         loader: 'babel'
       }
     ]
+  },
+  eslint: {
+    formatter: require('eslint-friendly-formatter')
   },
   plugins: []
 };

--- a/build/webpack.dev.config.js
+++ b/build/webpack.dev.config.js
@@ -1,20 +1,21 @@
 const webpack = require('webpack');
 const merge = require('webpack-merge');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const baseWebpackConfig = require('./webpack.base.config');
 const devServerConfig = require('./dev-server.config');
 
+// add hot-reload related code to entry chunks
+Object.keys(baseWebpackConfig.entry).forEach(function (name) {
+  baseWebpackConfig.entry[name] = [
+    'webpack-dev-server/client?http://' + devServerConfig.SERVER_HOST + ':' + devServerConfig.SERVER_PORT,
+    'webpack/hot/dev-server'
+  ].concat(baseWebpackConfig.entry[name]);
+});
+
 module.exports = merge(baseWebpackConfig, {
   debug: true,
   devtool: '#eval-source-map',
-  entry: {
-    app: [
-      'webpack-dev-server/client?http://' + devServerConfig.SERVER_HOST + ':' + devServerConfig.SERVER_PORT,
-      'webpack/hot/dev-server',
-      'babel-polyfill',
-      './src/js/app.js'
-    ]
-  },
   module: {
     loaders: [
       {
@@ -25,6 +26,13 @@ module.exports = merge(baseWebpackConfig, {
     ]
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin(),
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      template: 'index.html',
+      inject: true
+    })
   ]
 });

--- a/build/webpack.prod.config.js
+++ b/build/webpack.prod.config.js
@@ -31,7 +31,7 @@ module.exports = merge(baseWebpackConfig, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: '"production"'
+        NODE_ENV: 'production'
       }
     }),
     new webpack.optimize.UglifyJsPlugin({

--- a/build/webpack.prod.config.js
+++ b/build/webpack.prod.config.js
@@ -1,10 +1,22 @@
+/* eslint-disable no-process-env */
+
+const path = require('path');
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const config = require('../config');
 
 const baseWebpackConfig = require('./webpack.base.config');
 
 module.exports = merge(baseWebpackConfig, {
+  devtool: config.build.productionSourceMap ? '#source-map' : false,
+  output: {
+    path: config.build.assetsRoot,
+    filename: path.join(config.build.assetsSubDirectory, '[name].[chunkhash].js'),
+    chunkFilename: path.join(config.build.assetsSubDirectory, '[id].[chunkhash].js')
+  },
   module: {
     loaders: [
       {
@@ -17,16 +29,31 @@ module.exports = merge(baseWebpackConfig, {
     ]
   },
   plugins: [
-    new ExtractTextPlugin('../css/[name].css'),
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify('production')
+        NODE_ENV: '"production"'
       }
     }),
-    new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false
+      }
+    }),
+    new webpack.optimize.OccurenceOrderPlugin(),
+    // extract css into its own file
+    new ExtractTextPlugin(path.join(config.build.assetsSubDirectory, '[name].[contenthash].css')),
+    new HtmlWebpackPlugin({
+      filename: process.env.NODE_ENV === 'testing'
+        ? 'index.html'
+        : config.build.index,
+      template: 'index.html',
+      inject: true,
+      minify: {
+        removeComments: true,
+        collapseWhitespace: true,
+        removeAttributeQuotes: true
+        // more options:
+        // https://github.com/kangax/html-minifier#options-quick-reference
       }
     })
   ]

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+module.exports = {
+  build: {
+    index: path.resolve(__dirname, 'dist/index.html'),
+    assetsRoot: path.resolve(__dirname, 'dist'),
+    assetsSubDirectory: 'static',
+    assetsPublicPath: '/',
+    productionSourceMap: true
+  }
+};

--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@ module.exports = {
     index: path.resolve(__dirname, 'dist/index.html'),
     assetsRoot: path.resolve(__dirname, 'dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
+    assetsPublicPath: '',
     productionSourceMap: true
   }
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -114,7 +114,11 @@ gulp.task('webpack-dev-server', (callback) => {
     },
     publicPath: webpackDevConfig.output.publicPath,
     stats: {
-      colors: true
+      colors: true,
+      modules: false,
+      children: false,
+      chunks: false,
+      chunkModules: false
     }
   });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,6 @@ const gutil = require('gulp-util');
 const del = require('del');
 const mergeStream = require('merge-stream');
 
-const eslint = require('gulp-eslint');
 const esdoc = require('gulp-esdoc');
 
 const babel = require('gulp-babel');
@@ -38,20 +37,7 @@ gulp.task('docs', [ 'clean:docs' ], () => {
     .pipe(esdoc());
 });
 
-gulp.task('lint', () => {
-  return gulp.src([ SRC_FILES, TEST_FILES ])
-      .pipe(eslint())
-      .pipe(eslint.format())
-      .pipe(eslint.results((results) => {
-        // Called once for all ESLint results.
-        gutil.log('[lint]', 'Total Warnings: ' + results.warningCount);
-        gutil.log('[lint]', 'Total Errors: ' + results.errorCount);
-      }))
-      // exit if linting error is encountered
-      .pipe(eslint.failAfterError());
-});
-
-gulp.task('test', [ 'lint' ], (cb) => {
+gulp.task('test', (cb) => {
   mergeStream(
     gulp.src([ SRC_FILES ])
       .pipe(istanbul({
@@ -90,7 +76,7 @@ gulp.task('test', [ 'lint' ], (cb) => {
     });
 });
 
-gulp.task('clean', [ 'test' ], () => {
+gulp.task('clean', () => {
   return del([ BUILD_OUTPUT_DIR ]);
 });
 
@@ -110,7 +96,7 @@ gulp.task('webpack:build', [ 'prep' ], (callback) => {
   });
 });
 
-gulp.task('webpack-dev-server', [ 'prep' ], (callback) => {
+gulp.task('webpack-dev-server', (callback) => {
   var compiler = webpack(webpackDevConfig);
 
   compiler.plugin('done', () => {

--- a/index.html
+++ b/index.html
@@ -3,8 +3,6 @@
 
 <head>
   <title>Canvas Graph Creator</title>
-
-  <link rel="stylesheet" type="text/css" href="./dist/css/app.css" />
 </head>
 
 <body>
@@ -152,9 +150,6 @@
       <li class="context-menu__section__item" data-type="add" data-data="octagon">Add Octagon Node</li>
     </ul>
   </div>
-
-
-  <script src="./dist/js/app.js"></script>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/allenmyao/canvas-graph-creator.git"
   },
+  "scripts": {
+    "dev": "node build/dev-server.js"
+  },
   "devDependencies": {
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "url": "https://github.com/allenmyao/canvas-graph-creator.git"
   },
   "scripts": {
-    "dev": "node build/dev-server.js"
+    "dev": "node build/dev-server.js",
+    "build": "node build/build.js",
+    "test": "gulp test"
   },
   "devDependencies": {
     "babel-core": "^6.7.6",
@@ -34,6 +36,7 @@
     "mocha": "^2.4.5",
     "node-sass": "^3.4.2",
     "sass-loader": "^3.2.0",
+    "shelljs": "^0.6.0",
     "style-loader": "^0.13.1",
     "webpack": "^1.12.15",
     "webpack-dev-server": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "gulp-babel": "^6.1.2",
     "gulp-babel-istanbul": "^1.0.0",
     "gulp-esdoc": "^0.2.0",
-    "gulp-eslint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "gulp-util": "^3.0.7",
     "html-webpack-plugin": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-graph-creator",
-  "description": "JavaScript library for creating graphs on an HTML5 canvas",
+  "description": "Graph creator using HTML5 canvas",
   "version": "0.0.1",
   "repository": {
     "type": "git",
@@ -17,6 +17,8 @@
     "css-loader": "^0.23.1",
     "del": "^2.2.0",
     "esdoc-es7-plugin": "0.0.3",
+    "eslint-friendly-formatter": "^2.0.3",
+    "eslint-loader": "^1.3.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
@@ -25,6 +27,7 @@
     "gulp-eslint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "gulp-util": "^3.0.7",
+    "html-webpack-plugin": "^2.16.0",
     "merge-stream": "^1.0.0",
     "mocha": "^2.4.5",
     "node-sass": "^3.4.2",

--- a/readme.md
+++ b/readme.md
@@ -1,24 +1,55 @@
 # Canvas Graph Creator
 [![Build Status](https://travis-ci.org/allenmyao/canvas-graph-creator.svg?branch=master)](https://travis-ci.org/allenmyao/canvas-graph-creator) [![Test Coverage](https://codeclimate.com/github/allenmyao/canvas-graph-creator/badges/coverage.svg)](https://codeclimate.com/github/allenmyao/canvas-graph-creator/coverage) [![Issue Count](https://codeclimate.com/github/allenmyao/canvas-graph-creator/badges/issue_count.svg)](https://codeclimate.com/github/allenmyao/canvas-graph-creator)
 
+> Graph creator using HTML5 canvas
+
 ## Building
 
 Make sure you have Node installed.
 
 To build the code, run the following:
 ```bash
-# Install Gulp globally (required for Gulp to work)
-npm install -g gulp
-
 # Install dependencies
 npm install
 
-# Compile code to ./dist/js/app.js
+# Build project to ./dist
+npm run build
+```
+
+If you prefer using Gulp, run the following commands instead of `npm run build`:
+``` bash
+# Install Gulp globally (required for Gulp to work)
+npm install -g gulp
+
+# Build project to ./dist
 gulp build
+```
+
+## Testing
+
+Unit tests are written with Mocha (test framework) + Chai (assertion library). Unit tests can be run using the following command:
+``` bash
+# Run unit tests
+gulp test
+```
+
+Browser tests use the Selenium framework (requires Maven). In order for these tests to work, the app must be hosted on a server. Run the following commands:
+``` bash
+# Before running browser tests, host the app
+# Example:
+npm install -g http-server
+http-server ./dist --silent -p 8080 -a 0.0.0.0 &
+# kill the server afterwards: fuser -k 8080/tcp
+
+# Go to selenium test directory
+cd selenium-tests/
+
+# Run browser tests
+mvn test
 ```
 
 ## Development
 
-To run the Webpack Dev Server, simply run `gulp`. Browse to `http://localhost:8080/webpack-dev-server/index.html` to view the live app.
+A development server is provided with ESLint and [Hot Module Replacement (HMR)](https://webpack.github.io/docs/hot-module-replacement.html). HMR enables live reloading of modules as changes are made to the files.
 
-Alternatively, you can run `gulp build-dev` to watch/rebuild using Gulp/Webpack.
+To run the development server, run `npm run dev` or `gulp`. Navigate to `http://localhost:8080/webpack-dev-server/index.html` to view the app.

--- a/src/js/ui/context-menu.js
+++ b/src/js/ui/context-menu.js
@@ -1,5 +1,5 @@
-import { Node } from 'data/node/node';
-import { Edge } from 'data/edge/edge';
+import { Node } from '../data/node/node';
+import { Edge } from '../data/edge/edge';
 
 const MENU_TOGGLE_CLASS = 'context-menu--active';
 

--- a/src/js/ui/sidebar.js
+++ b/src/js/ui/sidebar.js
@@ -1,6 +1,6 @@
 import SidebarDisplay from '../ui/sidebar-display';
 import SidebarSelect from '../ui/sidebar-select';
-import SidebarAlgorithm from 'ui/sidebar-algorithm';
+import SidebarAlgorithm from '../ui/sidebar-algorithm';
 
 /**
  * This class manages the container for sidebar-content subclasses, and is responsible

--- a/src/js/ui/toolbar.js
+++ b/src/js/ui/toolbar.js
@@ -7,7 +7,7 @@ import { EditEdgeTool } from '../tool/editedge-tool';
 import { MetadataTool } from '../tool/metadata-tool';
 import { PanTool } from '../tool/pan-tool';
 import { SelectTool } from '../tool/select-tool';
-import { AlgorithmTool } from 'tool/algorithm-tool';
+import { AlgorithmTool } from '../tool/algorithm-tool';
 
 const TOOL_CLASS = 'tool';
 const TOOL_NAME_ATTR = 'data-tool';


### PR DESCRIPTION
- Update Webpack to run ESLint on modules before bundling (also works with dev server)
- Add Webpack plugin to inject assets into minified HTML file
- Add new scripts for build/dev-server that can be run without Gulp
- Remove `lint` Gulp task
- Remove `test` Gulp task dependency from build/dev-server tasks