### PR TITLE
Add label position updating

### DIFF
--- a/src/js/util/line-2d.js
+++ b/src/js/util/line-2d.js
@@ -1,0 +1,23 @@
+class Line2D {
+  a;
+  b;
+
+  constructor(a, b) {
+    this.a = a;
+    this.b = b;
+  }
+
+  get length() {
+    return this.a.distanceTo(this.b);
+  }
+
+  hasPoint(c) {
+    let ab = this.a.vectorTo(this.b);
+    let ac = this.a.vectorTo(c);
+    let cross = ab.cross(ac);
+    return Math.abs(cross) < 1e-8;
+  }
+}
+
+export { Line2D };
+export default Line2D;

--- a/src/js/util/line-2d.js
+++ b/src/js/util/line-2d.js
@@ -1,16 +1,45 @@
+/**
+ * Class representing 2D lines. Container for a pair of 2D points and some helper functions.
+ * @class Line2D
+ */
 class Line2D {
+
+  /**
+   * First point on the line.
+   * @type {Point2D}
+   */
   a;
+
+  /**
+   * Second point on the line.
+   * @type {Point2D}
+   */
   b;
 
+  /**
+   * Constructs a Line2D object.
+   * @param  {Point2D} a - First point of the line.
+   * @param  {Point2D} b - Second point of the line.
+   * @constructs Line2D
+   */
   constructor(a, b) {
     this.a = a;
     this.b = b;
   }
 
+  /**
+   * Getter for the length of the line.
+   * @return {number} - Length of the line.
+   */
   get length() {
     return this.a.distanceTo(this.b);
   }
 
+  /**
+   * Checks if the given point is on the line.
+   * @param  {Point2D} c - The point to check.
+   * @return {boolean} - Whether or not the given point is on the line.
+   */
   hasPoint(c) {
     let ab = this.a.vectorTo(this.b);
     let ac = this.a.vectorTo(c);

--- a/src/js/util/point-2d.js
+++ b/src/js/util/point-2d.js
@@ -1,19 +1,49 @@
 import Vector2D from './vector-2d';
 import Line2D from './line-2d';
 
+/**
+ * Class representing 2D points.
+ * @class Point2D
+ */
 class Point2D {
+
+  /**
+   * x-coordinate of the point.
+   * @type {number}
+   */
   x;
+
+  /**
+   * y-coordinate of the point.
+   * @type {number}
+   */
   y;
 
+  /**
+   * Constructs a Point2D object.
+   * @param {number} x - x-coordinate of the point.
+   * @param {number} y - y-coordinate of the point.
+   * @constructs Point2D
+   */
   constructor(x, y) {
     this.x = x;
     this.y = y;
   }
 
+  /**
+   * Checks if this point and another point are equal. Returns true if the x- and y-coordinates are equal.
+   * @param  {Point2D} point - Point to compare with.
+   * @return {boolean} - Whether or not the points are equivalent.
+   */
   equals(point) {
     return Math.abs(this.x - point.x) < 1e-8 && Math.abs(this.y - point.y) < 1e-8;
   }
 
+  /**
+   * Finds the distance between this point and another point.
+   * @param  {Point2D} point - Point to find th distance to.
+   * @return {number} - Distance between the points.
+   */
   distanceTo(point) {
     let dx = point.x - this.x;
     let dy = point.y - this.y;
@@ -21,6 +51,12 @@ class Point2D {
     return Math.abs(dist) < 1e-8 ? 0 : dist;
   }
 
+  /**
+   * Finds the coordinates this point should have relative to a triangle.
+   * @param  {Triangle2D} oldTriangle - Triangle2D object containing the triangle's old position.
+   * @param  {Triangle2D} newTriangle - Triangle2D object containing the triangle's new position.
+   * @return {Point2D} - Point representing the point's location relative the the triangle's new position.
+   */
   relativePositionToTriangle2D(oldTriangle, newTriangle) {
     if (this.equals(oldTriangle.a)) {
       return newTriangle.a;
@@ -34,18 +70,29 @@ class Point2D {
     return cartesianCoordiantes;
   }
 
-  translatePoint(point) {
-    return new Point2D(this.x + point.x, this.y + point.y);
-  }
-
+  /**
+   * Translates the point using a vector.
+   * @param  {Vector2D} vec - The vector to translate the point by.
+   * @return {Point2D} - Point resulting from the translation.
+   */
   translateVec(vec) {
     return new Point2D(this.x + vec.x, this.y + vec.y);
   }
 
+  /**
+   * Creates and returns a Line2D object using this point as the start point and another point as the end point.
+   * @param  {Point2D} point - Point to be used as the end point.
+   * @return {Line2D} - Line2D object created.
+   */
   lineTo(point) {
     return new Line2D(this, point);
   }
 
+  /**
+   * Finds the vector distance from this point to another point.
+   * @param  {Point2D} point - Point to find the vector distance to.
+   * @return {Vector2D} - Vector2D object representing the vector distance.
+   */
   vectorTo(point) {
     return new Vector2D(point.x - this.x, point.y - this.y);
   }

--- a/src/js/util/point-2d.js
+++ b/src/js/util/point-2d.js
@@ -1,0 +1,55 @@
+import Vector2D from './vector-2d';
+import Line2D from './line-2d';
+
+class Point2D {
+  x;
+  y;
+
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  equals(point) {
+    return Math.abs(this.x - point.x) < 1e-8 && Math.abs(this.y - point.y) < 1e-8;
+  }
+
+  distanceTo(point) {
+    let dx = point.x - this.x;
+    let dy = point.y - this.y;
+    let dist = Math.sqrt(dx * dx + dy * dy);
+    return Math.abs(dist) < 1e-8 ? 0 : dist;
+  }
+
+  relativePositionToTriangle2D(oldTriangle, newTriangle) {
+    if (this.equals(oldTriangle.a)) {
+      return newTriangle.a;
+    } else if (this.equals(oldTriangle.b)) {
+      return newTriangle.b;
+    } else if (this.equals(oldTriangle.c)) {
+      return newTriangle.c;
+    }
+    let barycentricCoordinates = oldTriangle.getBarycentricCoordinates(this);
+    let cartesianCoordiantes = newTriangle.getPointFromBarycentricCoordinates(barycentricCoordinates);
+    return cartesianCoordiantes;
+  }
+
+  translatePoint(point) {
+    return new Point2D(this.x + point.x, this.y + point.y);
+  }
+
+  translateVec(vec) {
+    return new Point2D(this.x + vec.x, this.y + vec.y);
+  }
+
+  lineTo(point) {
+    return new Line2D(this, point);
+  }
+
+  vectorTo(point) {
+    return new Vector2D(point.x - this.x, point.y - this.y);
+  }
+}
+
+export { Point2D };
+export default Point2D;

--- a/src/js/util/triangle-2d.js
+++ b/src/js/util/triangle-2d.js
@@ -1,30 +1,62 @@
 import Point2D from './point-2d';
 
+/**
+ * Class representing a 2D triangle.
+ * @class Triangle2D.
+ */
 class Triangle2D {
 
+  /**
+   * First endpoint of the triangle.
+   * @type {Point2D}
+   */
   a;
+
+  /**
+   * Second endpoint of the triangle.
+   * @type {Point2D}
+   */
   b;
+
+  /**
+   * Third endpoint of the triangle.
+   * @type {Point2D}
+   */
   c;
 
+  /**
+   * Constructs a Triangle2D object.
+   * @param  {Point2D} a - First endpoint of the triangle.
+   * @param  {Point2D} b - Second endpoint of the triangle.
+   * @param  {Point2D} c - Third endpoint of the triangle.
+   * @constructs Triangle2D
+   */
   constructor(a, b, c) {
     this.a = a;
     this.b = b;
     this.c = c;
   }
-
-  // get signed area of triangle
-  //
-  //   1  | x1 y1 1 |
-  //  --- | x2 y2 1 |
-  //   2! | x3 y3 1 |
-  //
-  // http://mathworld.wolfram.com/TriangleArea.html
+  /**
+   * Getter for the (signed) area of the triangle.
+   *
+   *          1  | x1 y1 1 |
+   * area =  --- | x2 y2 1 |
+   *          2  | x3 y3 1 |
+   *
+   * Source: http://mathworld.wolfram.com/TriangleArea.html
+   * @return {number} - Signed area of the triangle.
+   */
   get area() {
     return 0.5 * (-1 * this.b.y * this.c.x + this.a.y * (-1 * this.b.x + this.c.x) + this.a.x * (this.b.y - this.c.y) + this.b.x * this.c.y);
   }
 
-  // http://stackoverflow.com/a/14382692/1418962
-  // https://en.wikipedia.org/wiki/Barycentric_coordinate_system#Conversion_between_barycentric_and_Cartesian_coordinates
+  /**
+   * Find the barycentric coordinates of a point relative to this triangle.
+   * Source: http://stackoverflow.com/a/14382692/1418962
+   * More info: https://en.wikipedia.org/wiki/Barycentric_coordinate_system#Conversion_between_barycentric_and_Cartesian_coordinates
+   * @param  {Point2D} point - The point to find the barycentric coordinates of.
+   * @return {Point2D} - Point object containing the barycentric coordinates.
+   */
   getBarycentricCoordinates(point) {
     let area = this.area;
     let s = 1 / (2 * area) * (this.a.y * this.c.x - this.a.x * this.c.y + (this.c.y - this.a.y) * point.x + (this.a.x - this.c.x) * point.y);
@@ -32,6 +64,11 @@ class Triangle2D {
     return new Point2D(s, t);
   }
 
+  /**
+   * Find the cartesian coordinates of a point given its barycentric coordinates.
+   * @param  {Point2D} point - The point to find the coordinates of.
+   * @return {Point2D} - Point object containing the cartesian coordinates.
+   */
   getPointFromBarycentricCoordinates(point) {
     let s = point.x;
     let t = point.y;

--- a/src/js/util/triangle-2d.js
+++ b/src/js/util/triangle-2d.js
@@ -1,0 +1,45 @@
+import Point2D from './point-2d';
+
+class Triangle2D {
+
+  a;
+  b;
+  c;
+
+  constructor(a, b, c) {
+    this.a = a;
+    this.b = b;
+    this.c = c;
+  }
+
+  // get signed area of triangle
+  //
+  //   1  | x1 y1 1 |
+  //  --- | x2 y2 1 |
+  //   2! | x3 y3 1 |
+  //
+  // http://mathworld.wolfram.com/TriangleArea.html
+  get area() {
+    return 0.5 * (-1 * this.b.y * this.c.x + this.a.y * (-1 * this.b.x + this.c.x) + this.a.x * (this.b.y - this.c.y) + this.b.x * this.c.y);
+  }
+
+  // http://stackoverflow.com/a/14382692/1418962
+  // https://en.wikipedia.org/wiki/Barycentric_coordinate_system#Conversion_between_barycentric_and_Cartesian_coordinates
+  getBarycentricCoordinates(point) {
+    let area = this.area;
+    let s = 1 / (2 * area) * (this.a.y * this.c.x - this.a.x * this.c.y + (this.c.y - this.a.y) * point.x + (this.a.x - this.c.x) * point.y);
+    let t = 1 / (2 * area) * (this.a.x * this.b.y - this.a.y * this.b.x + (this.a.y - this.b.y) * point.x + (this.b.x - this.a.x) * point.y);
+    return new Point2D(s, t);
+  }
+
+  getPointFromBarycentricCoordinates(point) {
+    let s = point.x;
+    let t = point.y;
+    let x = (1 - s - t) * this.a.x + s * this.b.x + t * this.c.x;
+    let y = (1 - s - t) * this.a.y + s * this.b.y + t * this.c.y;
+    return new Point2D(x, y);
+  }
+}
+
+export { Triangle2D };
+export default Triangle2D;

--- a/src/js/util/vector-2d.js
+++ b/src/js/util/vector-2d.js
@@ -1,0 +1,71 @@
+import Point2D from './point-2d';
+
+class Vector2D {
+  x;
+  y;
+
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  get length() {
+    let len = Math.sqrt(this.x * this.x + this.y * this.y);
+    return Math.abs(len) < 1e-8 ? 0 : len;
+  }
+
+  equals(vec) {
+    return Math.abs(this.x - vec.x) < 1e-8 && Math.abs(this.y - vec.y) < 1e-8;
+  }
+
+  add(vec) {
+    return new Vector2D(this.x + vec.x, this.y + vec.y);
+  }
+
+  sub(vec) {
+    return new Vector2D(this.x - vec.x, this.y - vec.y);
+  }
+
+  dot(vec) {
+    return this.x * vec.x + this.y * vec.y;
+  }
+
+  cross(vec) {
+    return this.x * vec.y - this.y * vec.x;
+  }
+
+  scale(n) {
+    return new Vector2D(this.x * n, this.y * n);
+  }
+
+  rotateDegrees(deg) {
+    return this.rotateRadians(deg * (Math.PI / 180));
+  }
+
+  rotateRadians(rad) {
+    let cos = Math.cos(rad);
+    let sin = Math.sin(rad);
+    return new Vector2D(this.x * cos - this.y * sin, this.x * sin + this.y * cos);
+  }
+
+  degreesTo(vec) {
+    let angle = Math.atan2(vec.y, vec.x) - Math.atan2(this.y, this.x);
+    angle *= 180 / Math.PI;
+    angle = (angle + 360) % 360;
+    if (Math.abs(Math.round(angle) - angle) < 1e-8) {
+      return Math.round(angle);
+    }
+    return angle;
+  }
+
+  projectOnto(vec) {
+    return vec.scale(this.dot(vec) / vec.dot(vec));
+  }
+
+  toPoint() {
+    return new Point2D(this.x, this.y);
+  }
+}
+
+export { Vector2D };
+export default Vector2D;

--- a/src/js/util/vector-2d.js
+++ b/src/js/util/vector-2d.js
@@ -1,53 +1,122 @@
 import Point2D from './point-2d';
 
+/**
+ * Class for representing 2D vectors.
+ * @class Vector2D
+ */
 class Vector2D {
+
+  /**
+   * x component of the vector.
+   * @type {number}
+   */
   x;
+
+  /**
+   * y component of the vector.
+   * @type {number}
+   */
   y;
 
+  /**
+   * Constructs a Vector2D object.
+   * @param  {number} x - x-component of the vector.
+   * @param  {number} y - y-component of the vector.
+   * @constructs Vector2D
+   */
   constructor(x, y) {
     this.x = x;
     this.y = y;
   }
 
+  /**
+   * Getter for vector length.
+   * @return {number} - The length of the vector.
+   */
   get length() {
     let len = Math.sqrt(this.x * this.x + this.y * this.y);
     return Math.abs(len) < 1e-8 ? 0 : len;
   }
 
+  /**
+   * Checks if this vector and another vector are equal. Returns true if the x- and y-components are equal.
+   * @param  {Vector2D} vec - Vector to compare with.
+   * @return {boolean} - Whether or not the vectors are equivalent.
+   */
   equals(vec) {
     return Math.abs(this.x - vec.x) < 1e-8 && Math.abs(this.y - vec.y) < 1e-8;
   }
 
+  /**
+   * Finds the result of addition with another vector.
+   * @param {Vector2D} vec - The vector to add.
+   * @return {Vector2D} - The result of vector addition.
+   */
   add(vec) {
     return new Vector2D(this.x + vec.x, this.y + vec.y);
   }
 
+  /**
+   * Finds the result of subtracting another vector.
+   * @param {Vector2D} vec - The vector to subtract.
+   * @return {Vector2D} - The result of vector subtraction.
+   */
   sub(vec) {
     return new Vector2D(this.x - vec.x, this.y - vec.y);
   }
 
+  /**
+   * Finds the dot product between this vector and another vector.
+   * @param  {Vector2D} vec - Vector to find a dot product with.
+   * @return {number} - The value of the dot product.
+   */
   dot(vec) {
     return this.x * vec.x + this.y * vec.y;
   }
 
+  /**
+   * Finds the "cross product" between this vector and another vector.
+   * @param  {Vector2D} vec - Vector to find the cross product with.
+   * @return {number} - The value of the cross product. Zero means the vectors are parallel.
+   */
   cross(vec) {
     return this.x * vec.y - this.y * vec.x;
   }
 
+  /**
+   * Finds the vector resulting from multiplication by a scalar.
+   * @param  {number} n - The scalar to multiply by.
+   * @return {Vector2D} - Vector resulting from the scale.
+   */
   scale(n) {
     return new Vector2D(this.x * n, this.y * n);
   }
 
+  /**
+   * Finds the vector resulting from a rotation in degrees.
+   * @param  {number} deg - Angle (in degrees) to rotate.
+   * @return {Vector2D} - Vector resulting from the rotation.
+   */
   rotateDegrees(deg) {
     return this.rotateRadians(deg * (Math.PI / 180));
   }
 
+  /**
+   * Finds the vector resulting from a rotation in radians.
+   * @param  {number} rad - Angle (in radians) to rotate.
+   * @return {Vector2D} - Vector resulting from the rotation.
+   */
   rotateRadians(rad) {
     let cos = Math.cos(rad);
     let sin = Math.sin(rad);
     return new Vector2D(this.x * cos - this.y * sin, this.x * sin + this.y * cos);
   }
 
+  /**
+   * Finds the angle between two vectors (in degrees).
+   * @param  {Vector2D} vec - Vector to find the angle to.
+   * @return {number} - Angle between the vectors in degrees.
+   */
   degreesTo(vec) {
     let angle = Math.atan2(vec.y, vec.x) - Math.atan2(this.y, this.x);
     angle *= 180 / Math.PI;
@@ -58,10 +127,19 @@ class Vector2D {
     return angle;
   }
 
+  /**
+   * Finds the vector projection of this vector onto another vector.
+   * @param  {Vector2D} vec - Vector to project onto.
+   * @return {Vector2D} - Vector resulting from the vector projection.
+   */
   projectOnto(vec) {
     return vec.scale(this.dot(vec) / vec.dot(vec));
   }
 
+  /**
+   * Converts the Vector2D object to a Point2D object. x- and y-components of the vector are used as x- and y-coordinates for the point.
+   * @return {Point2D} - Point with the same x and y values as this vector.
+   */
   toPoint() {
     return new Point2D(this.x, this.y);
   }


### PR DESCRIPTION
- Added updating of label position relative to the edge
- Added helper classes to determine the label position
- Possible issues/bugs to fix:
  - When edge is originally curved and is turned into a straight edge, the label is reset to the bezierPoint, since there is no way to keep its position relative
  - Similarly, when an edge is originally straight, and is turned into a curved edge, the label is reset to the bezierPoint
  - When nodes are dragged on top of each other (such that the x- and y-coordinates are equal) the labels on the edges connecting them don't appear